### PR TITLE
Cleanup application versions

### DIFF
--- a/lib/jack_and_the_elastic_beanstalk/cli.rb
+++ b/lib/jack_and_the_elastic_beanstalk/cli.rb
@@ -18,6 +18,7 @@ module JackAndTheElasticBeanstalk
       def eb
         @eb ||= JackAndTheElasticBeanstalk::EB.new(application_name: config.app_name, logger: logger, client: client).tap do |eb|
           eb.timeout = options[:timeout] * 60
+          eb.keep_versions = options[:keep_versions]
         end
       end
 
@@ -60,6 +61,7 @@ module JackAndTheElasticBeanstalk
     class_option :loglevel, type: :string, enum: ["info", "debug", "error"], default: "error", desc: "Loglevel"
     class_option :jack_dir, type: :string, default: (Pathname.pwd + "jack").to_s, desc: "Directory to app.yml"
     class_option :source_dir, type: :string, default: Pathname.pwd.to_s, desc: "Directory for source code"
+    class_option :keep_versions, type: :numeric, default: 100, desc: "Number of application versions to keep"
 
     desc "create CONFIGURATION GROUP ENV_VAR=VALUE...", "Create new group"
     def create(configuration, group, *env_var_args)

--- a/lib/jack_and_the_elastic_beanstalk/cli.rb
+++ b/lib/jack_and_the_elastic_beanstalk/cli.rb
@@ -343,5 +343,11 @@ module JackAndTheElasticBeanstalk
         runner.stdout.puts JSON.pretty_generate(resources)
       end
     end
+
+    desc "cleanup", "Cleanup old application versions"
+    def cleanup
+      deleted_count = eb.cleanup_versions
+      runner.stdout.puts "Cleanup #{deleted_count} versions."
+    end
   end
 end

--- a/lib/jack_and_the_elastic_beanstalk/eb.rb
+++ b/lib/jack_and_the_elastic_beanstalk/eb.rb
@@ -47,12 +47,14 @@ module JackAndTheElasticBeanstalk
     end
 
     def cleanup_versions
-      return if application_versions.count < keep_versions
-      application_versions[keep_versions..-1].each do |version|
+      old_application_versions = application_versions[keep_versions..-1]
+      return 0 unless old_application_versions
+      old_application_versions.each do |version|
         client.delete_application_version(application_name: application_name,
                                           version_label: version.version_label,
                                           delete_source_bundle: true)
       end
+      old_application_versions.count
     end
 
     class Environment

--- a/lib/jack_and_the_elastic_beanstalk/service.rb
+++ b/lib/jack_and_the_elastic_beanstalk/service.rb
@@ -148,6 +148,8 @@ module JackAndTheElasticBeanstalk
 
         env.ensure_version!(expected_label: label)
       end
+
+      eb.cleanup_versions
     end
 
     def destroy(group:)


### PR DESCRIPTION
Elastic Beanstalk failed deployment when already have more 500 application versions.
ref: https://forums.aws.amazon.com/message.jspa?messageID=564329

After deployed, cleanup old application versions to maintain a specified number of versions (default is 100). 