### PR TITLE
Fix `shadowing outer local variable - env` warnings

### DIFF
--- a/lib/jack_and_the_elastic_beanstalk/service.rb
+++ b/lib/jack_and_the_elastic_beanstalk/service.rb
@@ -25,7 +25,7 @@ module JackAndTheElasticBeanstalk
         runner.capture3!("eb", "deploy", env_name(group: group, process: process), "--nohang")
       end
 
-      env = eb.environments.find {|env| env.environment_name == env_name(group: group, process: process) }
+      env = eb.environments.find {|e| e.environment_name == env_name(group: group, process: process) }
       env.synchronize_update
     end
 
@@ -72,7 +72,7 @@ module JackAndTheElasticBeanstalk
         end
 
         eb.refresh
-        env = eb.environments.find {|env| env.environment_name == env_name(group: group, process: process) }
+        env = eb.environments.find {|e| e.environment_name == env_name(group: group, process: process) }
         env.synchronize_update
       else
         logger.info("jeb::service") { "Environment #{env_name(group:group, process: process)} already exists..." }


### PR DESCRIPTION
With `-w` ruby option, this gem warns abount shadowing outer local variable.

```
/home/pocke/ghq/github.com/sideci/jack_and_the_elastic_beanstalk/lib/jack_and_the_elastic_beanstalk/service.rb:28: warning: shadowing outer local variable - env
/home/pocke/ghq/github.com/sideci/jack_and_the_elastic_beanstalk/lib/jack_and_the_elastic_beanstalk/service.rb:75: warning: shadowing outer local variable - env
```


This change fixes the warnings.