### PR TITLE
Let .env.local be loaded before .env

### DIFF
--- a/exe/jeb
+++ b/exe/jeb
@@ -3,5 +3,5 @@
 $LOAD_PATH << File.join(__dir__, "../lib")
 require "jack_and_the_elastic_beanstalk"
 
-Dotenv.load
+Dotenv.load(".env.local", ".env")
 JackAndTheElasticBeanstalk::CLI.start(ARGV)


### PR DESCRIPTION
`.env.local` can be used to override variables in `.env`.

`.env.local` の名前は https://github.com/bkeepers/dotenv から借用しています。