### PR TITLE
Insert config.app_name in env_name

### DIFF
--- a/lib/jack_and_the_elastic_beanstalk/service.rb
+++ b/lib/jack_and_the_elastic_beanstalk/service.rb
@@ -80,7 +80,7 @@ module JackAndTheElasticBeanstalk
     end
 
     def env_name(group:, process:)
-      "jeb-#{group}-#{process}"
+      "jeb-#{config.app_name}-#{group}-#{process}"
     end
 
     def stage(target_dir:, process:)
@@ -162,7 +162,7 @@ module JackAndTheElasticBeanstalk
 
     def each_environment(group:)
       if block_given?
-        regexp = /\Ajeb-#{group}-([^\-]+)\Z/
+        regexp = /\Ajeb-#{config.app_name}-#{group}-([^\-]+)\Z/
 
         eb.environments.each do |env|
           if env.environment_name =~ regexp
@@ -176,7 +176,7 @@ module JackAndTheElasticBeanstalk
 
     def each_group
       if block_given?
-        regexp = /\Ajeb-(.+)-([^\-]+)\Z/
+        regexp = /\Ajeb-#{config.app_name}-(.+)-([^\-]+)\Z/
 
         eb.environments.group_by {|env|
           if env.environment_name =~ regexp

--- a/lib/jack_and_the_elastic_beanstalk/version.rb
+++ b/lib/jack_and_the_elastic_beanstalk/version.rb
@@ -1,3 +1,3 @@
 module JackAndTheElasticBeanstalk
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This PR inserts application name in an environment name because Elastic Beanstalk environment name must be unique within a region in an account.

https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CreateEnvironment.html

Renaming environment names causes breaking change, so I updated gem version to 0.2.0.