### PR TITLE
Wait longer until next polling during deploying

### DIFF
--- a/lib/jack_and_the_elastic_beanstalk/eb.rb
+++ b/lib/jack_and_the_elastic_beanstalk/eb.rb
@@ -146,7 +146,7 @@ module JackAndTheElasticBeanstalk
         yield if block_given?
 
         start = Time.now
-        wait = 1
+        wait = 30
 
         while true
           refresh
@@ -168,7 +168,7 @@ module JackAndTheElasticBeanstalk
           end
 
           sleep wait
-          wait = [wait*2, 30].min
+          wait = [wait*2, 120].min
         end
 
         logger.info("jeb::eb") { "Synchronized in #{(Time.now - start).to_i} seconds" }


### PR DESCRIPTION
We sometimes suffer from a rate limit of AWS. To avoid it, I made `jeb` wait longer until the next polling.